### PR TITLE
fix: 臨時修復一些UI bug

### DIFF
--- a/apps/mobile/business/playlist/shuffle.ts
+++ b/apps/mobile/business/playlist/shuffle.ts
@@ -1,6 +1,15 @@
 import { QUEUE_IS_RANDOMIZED, QUEUE_PLAYING_MODE, QueuePlayingMode, queueStorage } from "~/storage/queue";
 import { loadBackupTrackData } from "~/business/playlist/handler";
-import { addTracks, deleteTracks, getCurrentTrackIndex, getTracks, jump, setQueue } from "@bilisound/player";
+import {
+    addTracks,
+    deleteTracks,
+    getCurrentTrackIndex,
+    getProgress,
+    getTracks,
+    jump,
+    seek,
+    setQueue,
+} from "@bilisound/player";
 import { TrackData } from "@bilisound/player/build/types";
 import { Platform } from "react-native";
 
@@ -121,6 +130,8 @@ export async function shuffleQueue() {
 export async function restoreQueue(originalTracks: TrackData[]): Promise<void> {
     const currentTrackIndex = await getCurrentTrackIndex();
     const currentQueue = await getTracks();
+    const progress = await getProgress();
+
     const currentTrack = currentQueue[currentTrackIndex];
 
     // Find the index of the current track in the original list
@@ -136,17 +147,15 @@ export async function restoreQueue(originalTracks: TrackData[]): Promise<void> {
         // If the current track is not in the original list, just set the queue to the original tracks
         return setQueue(originalTracks);
     }
-
     const [removeLeft, removeRight] = generateIndicesArrays(currentQueue.length, currentTrackIndex);
-
     // 移除当前播放的曲目后面的所有曲目
     await deleteTracks(removeRight);
 
     // 移除当前播放的曲目前面的所有曲目
     await deleteTracks(removeLeft);
-
     const [insertLeft, insertRight] = splitArrayAtIndex(originalTracks, originalIndex);
 
+    // ! 這裏會導致 iOS 列表錯亂
     // 在前面插入新列表的曲目
     await addTracks(insertLeft, 0);
 
@@ -154,6 +163,8 @@ export async function restoreQueue(originalTracks: TrackData[]): Promise<void> {
     await addTracks(insertRight);
 
     if (Platform.OS === "ios") {
+        // ! 臨時解決方案，應該修改player部分
         await jump(originalIndex);
+        await seek(progress.position);
     }
 }

--- a/apps/mobile/business/playlist/shuffle.ts
+++ b/apps/mobile/business/playlist/shuffle.ts
@@ -147,7 +147,9 @@ export async function restoreQueue(originalTracks: TrackData[]): Promise<void> {
         // If the current track is not in the original list, just set the queue to the original tracks
         return setQueue(originalTracks);
     }
+
     const [removeLeft, removeRight] = generateIndicesArrays(currentQueue.length, currentTrackIndex);
+
     // 移除当前播放的曲目后面的所有曲目
     await deleteTracks(removeRight);
 

--- a/apps/mobile/components/ui/menu/index.tsx
+++ b/apps/mobile/components/ui/menu/index.tsx
@@ -120,9 +120,10 @@ const Menu = React.forwardRef<React.ElementRef<typeof UIMenu>, IMenuProps>(({ cl
     return (
         <UIMenu
             ref={ref}
+            // 要暫時刪除scale動畫，因為存在bug: https://github.com/gluestack/gluestack-ui/issues/2613#issuecomment-2606537026
             initial={{
                 opacity: 0,
-                scale: 0.8,
+                scale: 1,
             }}
             animate={{
                 opacity: 1,


### PR DESCRIPTION
## 描述

都是臨時修復的方案

1. 臨時修復iOS下 隨機播放導致曲目錯亂的bug
2. 臨時修復menu在播放列表長度大於1時，scale動畫不會被觸發的[問題](https://github.com/user-attachments/assets/2d6751ec-2945-4962-860e-eaa19eec58de)



Uploading Simulator Screen Recording - iPhone 16 Pro Max - 2025-05-04 at 00.25.18.mp4…


