### PR TITLE
ci: update release workflow actions for Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🏗 Generate build version
         id: build_version
@@ -40,11 +40,12 @@ jobs:
           echo "$BILISOUND_KEYSTORE_RELEASE" | base64 --decode > credentials/bilisound-release.keystore
 
       - name: 🏗 Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
+          node-version: "24"
           cache: pnpm
 
       - name: 🏗 Set build version
@@ -63,14 +64,14 @@ jobs:
           pnpm run prebuild
 
       - name: 🏗 Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: "temurin"
           cache: gradle
 
       - name: 🏗 Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v5
 
       - name: 🚀 Build Android app
         working-directory: apps/mobile
@@ -96,7 +97,7 @@ jobs:
 
       - name: 📝 Extract Release Notes
         id: extract_release_notes
-        uses: ffurrer2/extract-release-notes@v2
+        uses: ffurrer2/extract-release-notes@v3
         with:
           changelog_file: apps/mobile/CHANGELOG.md
           prerelease: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
### Motivation

- The release workflow emitted Node 20 deprecation warnings in CI, so the workflow actions and runtime need to be upgraded to versions that target Node 24 to remove those warnings.

### Description

- Updated `.github/workflows/release.yml` to use newer Action versions and set the workflow Node runtime to `24`, including `actions/checkout@v5`, `pnpm/action-setup@v6`, `actions/setup-node@v5` (with `node-version: "24"`), and `actions/setup-java@v5` while keeping the existing pnpm cache configuration.
- Replaced the deprecated Gradle action with `gradle/actions/setup-gradle@v5` and bumped `ffurrer2/extract-release-notes` to `@v3`.

### Testing

- Ran `ruby -e 'require "yaml"; p YAML.load_file(".github/workflows/release.yml").keys'` to validate the workflow YAML structure, which succeeded. 
- Searched for old action pins and Node 20 references with `rg`, which returned no remaining `@v4`/`node20` matches in the workflow file. 
- Ran `pnpm exec prettier --check .github/workflows/release.yml` to confirm formatting, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a520e34cbb0833380f230231b54179a)